### PR TITLE
Allow overriding the default trustlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Create a .env file or set the following environment variables before running to 
 | **START_HEIGHT** | Block height to start indexing | block shortly before sep 2020
 | **TIMEOUT** | Network timeout in milliseconds | 10000
 | **MEMPOOL_EXPIRATION** | Seconds until transactions are removed from the mempool | 86400
+| **DEFAULT_TRUSTLIST** | Comma-separated values of trusted txids | predefined trustlist
 
 ## Endpoints
 

--- a/src/config.js
+++ b/src/config.js
@@ -28,7 +28,7 @@ require('axios').default.defaults.timeout = TIMEOUT
 // Default trustlist
 // ------------------------------------------------------------------------------------------------
 
-const DEFAULT_TRUSTLIST = [
+const DEFAULT_TRUSTLIST = process.env.DEFAULT_TRUSTLIST.split(",").filter(t => t) || [
   /**
    * RUN ▸ Extras
    */


### PR DESCRIPTION
Checks if a default trustlist has been defined in the .env file and will use it instead of the trustlist that came with the source code.
It is also possible to start with no trusted txid when the server starts by not adding any txid to the .env file.