### PR TITLE
Add validation to DEFAULT_TRUSTLIST environment variable

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -32,6 +32,8 @@ function isValidTxId(txId) {
   const isValid = (/^[0-9A-Fa-f]{64}$/g).test(txId)
 
   if(!isValid) throw new Error('Invalid DEFAULT_TRUSTLIST value: "' + txId + '"')
+
+  return true;
 }
 
 const ENV_VAR_DEFAULT_TRUSTLIST = process.env.DEFAULT_TRUSTLIST && process.env.DEFAULT_TRUSTLIST.split(',').filter(isValidTxId)

--- a/src/config.js
+++ b/src/config.js
@@ -29,7 +29,7 @@ require('axios').default.defaults.timeout = TIMEOUT
 // ------------------------------------------------------------------------------------------------
 
 function isValidTxId(txId) {
-  const isValid = (/^[0-9A-Fa-f]{64}$/g).test(txId);
+  const isValid = (/^[0-9A-Fa-f]{64}$/g).test(txId)
 
   if(!isValid) throw new Error('Invalid DEFAULT_TRUSTLIST value: "' + txId + '"')
 }

--- a/src/config.js
+++ b/src/config.js
@@ -28,7 +28,13 @@ require('axios').default.defaults.timeout = TIMEOUT
 // Default trustlist
 // ------------------------------------------------------------------------------------------------
 
-const ENV_VAR_DEFAULT_TRUSTLIST = process.env.DEFAULT_TRUSTLIST && process.env.DEFAULT_TRUSTLIST.split(',').filter(t => t)
+function isValidTxId(txId) {
+  const isValid = (/^[0-9A-Fa-f]{64}$/g).test(txId);
+
+  if(!isValid) throw new Error('Invalid DEFAULT_TRUSTLIST value: "' + txId + '"')
+}
+
+const ENV_VAR_DEFAULT_TRUSTLIST = process.env.DEFAULT_TRUSTLIST && process.env.DEFAULT_TRUSTLIST.split(',').filter(isValidTxId)
 
 const DEFAULT_TRUSTLIST = ENV_VAR_DEFAULT_TRUSTLIST || [
   /**


### PR DESCRIPTION
I thought the BSV library would have a utility function to validate a transaction id, but I couldn't seem to find one.  However, it seems to be just a string of length 64 containing hex characters.

Also, from an organizational perspective, I'm not sure if you'd like this function in some other location.

![image](https://user-images.githubusercontent.com/128739/120948326-a01ebe80-c707-11eb-8303-25659d62583c.png)
