### PR TITLE
Add webhook to send data to external services

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Create a .env file or set the following environment variables before running to 
 | **TIMEOUT** | Network timeout in milliseconds | 10000
 | **MEMPOOL_EXPIRATION** | Seconds until transactions are removed from the mempool | 86400
 | **DEFAULT_TRUSTLIST** | Comma-separated values of trusted txids | predefined trustlist
+| **WEBHOOK_URL** | Service to POST jig data. The origin will be appended to the path.
 
 ## Endpoints
 

--- a/src/config.js
+++ b/src/config.js
@@ -21,8 +21,18 @@ const FETCH_LIMIT = process.env.FETCH_LIMIT || 20
 const START_HEIGHT = process.env.START_HEIGHT || (NETWORK === 'test' ? 1382000 : 650000)
 const TIMEOUT = process.env.TIMEOUT || 10000
 const MEMPOOL_EXPIRATION = process.env.MEMPOOL_EXPIRATION || 60 * 60 * 24
+const WEBHOOK_URL = process.env.WEBHOOK_URL || '';
 
 require('axios').default.defaults.timeout = TIMEOUT
+
+if(WEBHOOK_URL) {
+  try {
+    // validate url string
+    new URL(WEBHOOK_URL)
+  } catch {
+    throw new Error('Invalid WEBHOOK_URL value: ' + WEBHOOK_URL)
+  }
+}
 
 // ------------------------------------------------------------------------------------------------
 // Default trustlist
@@ -106,5 +116,6 @@ module.exports = {
   FETCH_LIMIT,
   START_HEIGHT,
   MEMPOOL_EXPIRATION,
-  DEFAULT_TRUSTLIST
+  DEFAULT_TRUSTLIST,
+  WEBHOOK_URL
 }


### PR DESCRIPTION
This is a proposal to add a webhook to run db.  The motivation is in being able to leverage the indexing and state calculation work being done by run-db and piping that data to other services.

An example use case might be to leverage a cheap cloud service like Firebase's Firestore.  The data is not readily available without running a more resource-intensive server.  However, with a webhook, a node could be run cheaply from a desktop which posts the data for the transactions of interest to the cloud service. 

Example from a dummy service logging the path and posted data
![image](https://user-images.githubusercontent.com/128739/120959741-14fdf280-c720-11eb-883a-e96694473a4d.png)
