### PR TITLE
Use bsv node rest api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5686,9 +5686,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.0.tgz",
-      "integrity": "sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==",
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.6.tgz",
+      "integrity": "sha512-oaWyu5dQbHaYcyZCTfyPpC+VmI62/OM2RTUYavTk1MDr1cwW5Boi3baeYQKiZbY2uSQJGr+iMOzb/JFxLrft+g==",
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -10615,9 +10615,9 @@
       }
     },
     "tar": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.0.tgz",
-      "integrity": "sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==",
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.6.tgz",
+      "integrity": "sha512-oaWyu5dQbHaYcyZCTfyPpC+VmI62/OM2RTUYavTk1MDr1cwW5Boi3baeYQKiZbY2uSQJGr+iMOzb/JFxLrft+g==",
       "requires": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",

--- a/src/bitcoin-node-connection.js
+++ b/src/bitcoin-node-connection.js
@@ -49,12 +49,8 @@ class BitcoinNodeConnection {
       return { reorg: true }
     }
 
-    if (blockData.size >= 0xf000000) { // Avoids create a string longer than the limit
-      return this._responsefromBlockData(blockData)
-    }
-
     const block = this._parseBlock(
-      await this.rpc.getBlockByHeight(targetBlockHeight, false),
+      await this.rpc.getRawBlockByHash(blockData.hash),
       targetBlockHeight
     )
     return this._buildBlockResponse(block, targetBlockHeight)
@@ -90,8 +86,8 @@ class BitcoinNodeConnection {
     return response
   }
 
-  _parseBlock (rpcResponse, requestedHeight) {
-    const bsvBlock = new bsv.Block(Buffer.from(rpcResponse, 'hex'))
+  _parseBlock (blockBuffer, requestedHeight) {
+    const bsvBlock = new bsv.Block(blockBuffer)
 
     return {
       height: requestedHeight,

--- a/src/bitcoin-rpc.js
+++ b/src/bitcoin-rpc.js
@@ -1,4 +1,3 @@
-const { response } = require('express')
 const fetch = require('node-fetch')
 
 const httpPost = async (url, jsonBody) => {

--- a/src/bitcoin-rpc.js
+++ b/src/bitcoin-rpc.js
@@ -47,6 +47,11 @@ class BitcoinRpc {
     return this._rpcCall('getblockbyheight', [targetHeight, verbose])
   }
 
+  async getRawBlockByHash (targetHash) {
+    const response = this._httpPost(`${this.baseUrl}/rest/block/${targetHash}.bin`)
+    return Buffer.from(await response.arrayBuffer())
+  }
+
   async _rpcCall (method, params) {
     const response = await this._httpPost(this.baseUrl, {
       jsonrpc: '1.0',

--- a/src/bitcoin-rpc.js
+++ b/src/bitcoin-rpc.js
@@ -1,3 +1,4 @@
+const { response } = require('express')
 const fetch = require('node-fetch')
 
 const httpPost = async (url, jsonBody) => {
@@ -28,6 +29,11 @@ class BitcoinRpc {
     this.baseUrl = baseUrl
   }
 
+  async isRestApiEnabled () {
+    const response = fetch(`${this.baseUrl}/rest/tx/9834daa6d34690981888f7db4c1c36686ebb9b685d37115abc38e0e75f9cd98d.hex`)
+    return response.ok
+  }
+
   /**
    * @param {String} txid
    */
@@ -48,7 +54,7 @@ class BitcoinRpc {
   }
 
   async getRawBlockByHash (targetHash) {
-    const response = this._httpPost(`${this.baseUrl}/rest/block/${targetHash}.bin`)
+    const response = await fetch(`${this.baseUrl}/rest/block/${targetHash}.bin`)
     return Buffer.from(await response.arrayBuffer())
   }
 

--- a/src/indexer.js
+++ b/src/indexer.js
@@ -117,7 +117,7 @@ class Indexer {
   }
 
   _onAddTransaction (txid) {
-    this.logger.info('Added', txid)
+    this.logger.debug('Added', txid)
   }
 
   _onDeleteTransaction (txid) {

--- a/test/bitcoin-node-connection-test.js
+++ b/test/bitcoin-node-connection-test.js
@@ -41,9 +41,15 @@ class TestBitcoinRpc {
       return {
         size: block.size || block.hex.length,
         previousblockhash: block.previousblockhash,
-        tx: block.txs.map(tx => tx.hash)
+        tx: block.txs.map(tx => tx.hash),
+        hash: block.hash
       }
     }
+  }
+
+  async getRawBlockByHash (targetHash) {
+    const block = this.blocks.find(block => block.hash === targetHash)
+    return Buffer.from(block.hex, 'hex')
   }
 
   // Test

--- a/test/bitcoin-node-connection-test.js
+++ b/test/bitcoin-node-connection-test.js
@@ -397,14 +397,14 @@ describe('BitcoinNodeConnection', () => {
       beforeEach(() => {
         bitcoinRpc.isRestEnabled = false
       })
-      it ('does not get txs one by one', async () => {
+      it('does not get txs one by one', async () => {
         const randomTx = buildRandomTx()
         const randomRunTx = await buildRandomRunTx(run)
         bitcoinRpc.registerUnconfirmedTx(randomTx.hash, randomTx.toBuffer().toString('hex'))
         bitcoinRpc.registerUnconfirmedTx(randomRunTx.hash, randomRunTx.toBuffer().toString('hex'))
         bitcoinRpc.closeBlock(0x1fffffe8 + 1)
         const previousBlock = bitcoinRpc.blocks[bitcoinRpc.blocks.length - 2]
-  
+
         expect(instance.getNextBlock(previousBlock.height, null)).not.to.eventually.throw()
       })
     })
@@ -420,9 +420,9 @@ describe('BitcoinNodeConnection', () => {
         bitcoinRpc.registerUnconfirmedTx(randomRunTx.hash, randomRunTx.toBuffer().toString('hex'))
         bitcoinRpc.closeBlock(0x1fffffe8 + 1)
 
-        bitcoinRpc.getRawTransaction = () => {  throw new Error('should not call') }
+        bitcoinRpc.getRawTransaction = () => { throw new Error('should not call') }
         const previousBlock = bitcoinRpc.blocks[bitcoinRpc.blocks.length - 2]
-  
+
         const nextBlock = await instance.getNextBlock(previousBlock.height, null)
         expect(nextBlock.txhexs.length).to.eql(nextBlock.txids.length)
       })


### PR DESCRIPTION
By using bsv's rest api we avoid all the issues related to block size and json/string/js limits becase we can directly interpret everything as a buffer.

